### PR TITLE
use active page width instead of document

### DIFF
--- a/js/jquery.mobile.simpledialog.js
+++ b/js/jquery.mobile.simpledialog.js
@@ -77,7 +77,7 @@
 	_orientChange: function(e) {
 		var self = $(e.currentTarget).data('simpledialog'),
 			o = self.options,
-			docWinWidth = $(document).width(),
+			docWinWidth = $.mobile.activePage.width(),
 			docWinHeightOffset = $(window).scrollTop(),
 			docWinHeight = $(window).height(),
 			pickWinHeight = self.pickerContent.outerHeight(),
@@ -103,7 +103,7 @@
 
 		var self = this,
 			o = this.options,
-			docWinWidth = $(document).width(),
+			docWinWidth = $.mobile.activePage.width(),
 			docWinHeightOffset = $(window).scrollTop(),
 			docWinHeight = $(window).height(),
 			pickWinHeight = self.pickerContent.outerHeight(),
@@ -296,7 +296,7 @@
 	_reposition: function() {
 		var self = this,
 			o = this.options,
-			docWinWidth = $(document).width(),
+			docWinWidth = $.mobile.activePage.width(),
 			docWinHeightOffset = $(window).scrollTop(),
 			docWinHeight = $(window).height(),
 			pickWinHeight = self.pickerContent.outerHeight(),


### PR DESCRIPTION
Allows use of simple dialog when page width is not the same as document width
in this case the dialog does not correctly appear centred in the page.
