### PR TITLE
Removing dialog from DOM on full screen mode

### DIFF
--- a/js/jquery.mobile.simpledialog.js
+++ b/js/jquery.mobile.simpledialog.js
@@ -180,16 +180,17 @@
 		fromCloseButton = ( typeof(fromCloseButton) === 'undefined' ) ? false : fromCloseButton;
 
 		if ( self.options.useDialog ) {
+			if( self.options.cleanOnClose === true ){
+                            self.pickPage.bind( "pagehide", function() {
+                              self.clean();
+                            });
+			} else {
+                          self.pickerContent.addClass('ui-simpledialog-hidden');
+                          self.thisPage.append(self.pickerContent);
+                        }
 			if ( fromCloseButton === false ) {
 				$(self.pickPage).dialog('close');
 			}
-			if( (typeof self.thisPage.jqmData("page")) !== 'undefined' && ! self.thisPage.jqmData("page").options.domCache ){
-				self.thisPage.bind( "pagehide.remove", function() {
-					$(self).remove();
-				});
-			}
-			self.pickerContent.addClass('ui-simpledialog-hidden');
-			self.thisPage.append(self.pickerContent);
 		} else {
 			if ( self.options.useModal ) {
 				if ( self.options.animate === true ) {


### PR DESCRIPTION
Hi,

This fixes 2 issues for me.

1) After closing the dialog remained in DOM in full screen mode (when useDialog === true). Moreover, it polluted DOM each time I open/close the dialog, so it accumulated. I am using it on one-page application build with backbone.js and need to make sure the DOM is cleaned properly.

2) The following code caused a nasty visual glitch in full screen mode: just before closing, it removed the content portion of the dialog, so it shrank to just a title bar and blank content and remained this way for a second before closing. So I removed it as well for `cleanOnClose` mode:

``` javascript
self.pickerContent.addClass('ui-simpledialog-hidden');
self.thisPage.append(self.pickerContent);
```

I definitely done everything wrong, please advise if there is a better approach to fix these two bugs.

Thank you for your work. Cool plugin.

---

Evgeny
