### PR TITLE
Partial fix for issue #48

### DIFF
--- a/css/jquery.mobile.simpledialog.css
+++ b/css/jquery.mobile.simpledialog.css
@@ -8,7 +8,7 @@
 /* Shared Styles */
 
 .ui-simpledialog-header h4 { margin-top: 5px; margin-bottom: 5px; text-align: center; }
-.ui-simpledialog-container { border: 5px solid #111 !important; width:85%; max-width:500px;}
+.ui-simpledialog-container { border: 5px solid #111 !important; width:85%; max-width:500px; -webkit-transform:translate3d(0,0,0); }
 .ui-simpledialog-screen { position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; }
 .ui-simpledialog-hidden { display: none; }
 .ui-simpledialog-input { width: 85% !important; display: block !important; margin-left: auto; margin-right: auto;}


### PR DESCRIPTION
Resolves z-index issue in Android 4.0.4 browser when using fade transition or animate: false. JQM (1.1.1) overwrites the -webkit-transform property for other transition types.
