### PR TITLE
Allow the dialog content to stay in DOM after the dialog window is closed

### DIFF
--- a/js/jquery.mobile.simpledialog2.js
+++ b/js/jquery.mobile.simpledialog2.js
@@ -338,7 +338,6 @@
 		if ( self.options.mode === 'blank' ) {
 			$.mobile.sdCurrentDialog.sdIntContent.find('select').each(function() {
 				if ( $(this).data('nativeMenu') == false ) {
-				  // not here
 				  $(this).data('selectmenu').menuPage.remove();
 					$(this).data('selectmenu').screen.remove();
 					$(this).data('selectmenu').listbox.remove();
@@ -352,7 +351,7 @@
 		}
 		else {
 		  $(self.sdIntContent).hide();
-    		}
+    	}
 		
 		$(self.dialogPage).remove();
 		$(self.screen).remove();

--- a/js/jquery.mobile.simpledialog2.js
+++ b/js/jquery.mobile.simpledialog2.js
@@ -45,8 +45,6 @@
 		callbackOpenArgs: [],
 		callbackClose: false,
 		callbackCloseArgs: [],
-		
-		// newly added
 		removeOnClose: true
 	},
 	_eventHandler: function(e,p) {
@@ -354,7 +352,7 @@
 		}
 		else {
 		  $(self.sdIntContent).hide();
-    }
+    		}
 		
 		$(self.dialogPage).remove();
 		$(self.screen).remove();

--- a/js/jquery.mobile.simpledialog2.js
+++ b/js/jquery.mobile.simpledialog2.js
@@ -44,7 +44,10 @@
 		callbackOpen: false,
 		callbackOpenArgs: [],
 		callbackClose: false,
-		callbackCloseArgs: []
+		callbackCloseArgs: [],
+		
+		// newly added
+		removeOnClose: true
 	},
 	_eventHandler: function(e,p) {
 		// Handle the triggers
@@ -260,7 +263,7 @@
 					setTimeout("$.mobile.sdCurrentDialog.destroy();", 1000);
 				});
 			} else {
-				self.dialogPage.find('.ui-header a').hide();
+			  self.dialogPage.find('.ui-header a').remove();
 			}
 			
 			self.sdIntContent.removeClass().css({'top': 'auto', 'width': 'auto', 'left': 'auto', 'marginLeft': 'auto', 'marginRight': 'auto', 'zIndex': o.zindex});
@@ -302,10 +305,11 @@
 		if ( self.isDialog ) {
 			$(self.dialogPage).dialog('close');
 			self.sdIntContent.addClass('ui-simpledialog-hidden');
+			console.log(self.displayAnchor.parent());
 			self.sdIntContent.appendTo(self.displayAnchor.parent());
 			if ( $.mobile.activePage.jqmData("page").options.domCache != true && $.mobile.activePage.is(":jqmData(external-page='true')") ) {
 				$.mobile.activePage.bind("pagehide.remove", function () {
-					$(this).hide();
+				  $(this).remove();
 				});
 			}
 		} else {
@@ -337,21 +341,29 @@
 		if ( self.options.mode === 'blank' ) {
 			$.mobile.sdCurrentDialog.sdIntContent.find('select').each(function() {
 				if ( $(this).data('nativeMenu') == false ) {
-					$(this).data('selectmenu').menuPage.hide();
-					$(this).data('selectmenu').screen.hide();
-					$(this).data('selectmenu').listbox.hide();
+				  // not here
+				  $(this).data('selectmenu').menuPage.remove();
+					$(this).data('selectmenu').screen.remove();
+					$(this).data('selectmenu').listbox.remove();
 				}
 			});
 		}
+
+		// in case we don't want a content div to be removed from DOM
+		if( self.options.removeOnClose === true ) {
+		  $(self.sdIntContent).remove();
+		}
+		else {
+		  $(self.sdIntContent).hide();
+    }
 		
-		$(self.sdIntContent).hide();
-		$(self.dialogPage).hide();
-		$(self.screen).hide();
+		$(self.dialogPage).remove();
+		$(self.screen).remove();
 		$(document).unbind('simpledialog.'+self.internalID);
 		delete $.mobile.sdCurrentDialog;
 		$.Widget.prototype.destroy.call(self);
 		if ( self.options.safeNuke === true && $(ele).parents().length === 0 && $(ele).contents().length === 0 ) {
-			ele.hide();
+			ele.remove();
 		}
 	},
 	updateBlank: function (newHTML) {

--- a/js/jquery.mobile.simpledialog2.js
+++ b/js/jquery.mobile.simpledialog2.js
@@ -260,7 +260,7 @@
 					setTimeout("$.mobile.sdCurrentDialog.destroy();", 1000);
 				});
 			} else {
-				self.dialogPage.find('.ui-header a').remove();
+				self.dialogPage.find('.ui-header a').hide();
 			}
 			
 			self.sdIntContent.removeClass().css({'top': 'auto', 'width': 'auto', 'left': 'auto', 'marginLeft': 'auto', 'marginRight': 'auto', 'zIndex': o.zindex});
@@ -305,7 +305,7 @@
 			self.sdIntContent.appendTo(self.displayAnchor.parent());
 			if ( $.mobile.activePage.jqmData("page").options.domCache != true && $.mobile.activePage.is(":jqmData(external-page='true')") ) {
 				$.mobile.activePage.bind("pagehide.remove", function () {
-					$(this).remove();
+					$(this).hide();
 				});
 			}
 		} else {
@@ -337,21 +337,21 @@
 		if ( self.options.mode === 'blank' ) {
 			$.mobile.sdCurrentDialog.sdIntContent.find('select').each(function() {
 				if ( $(this).data('nativeMenu') == false ) {
-					$(this).data('selectmenu').menuPage.remove();
-					$(this).data('selectmenu').screen.remove();
-					$(this).data('selectmenu').listbox.remove();
+					$(this).data('selectmenu').menuPage.hide();
+					$(this).data('selectmenu').screen.hide();
+					$(this).data('selectmenu').listbox.hide();
 				}
 			});
 		}
 		
-		$(self.sdIntContent).remove();
-		$(self.dialogPage).remove();
-		$(self.screen).remove();
+		$(self.sdIntContent).hide();
+		$(self.dialogPage).hide();
+		$(self.screen).hide();
 		$(document).unbind('simpledialog.'+self.internalID);
 		delete $.mobile.sdCurrentDialog;
 		$.Widget.prototype.destroy.call(self);
 		if ( self.options.safeNuke === true && $(ele).parents().length === 0 && $(ele).contents().length === 0 ) {
-			ele.remove();
+			ele.hide();
 		}
 	},
 	updateBlank: function (newHTML) {

--- a/js/jquery.mobile.simpledialog2.js
+++ b/js/jquery.mobile.simpledialog2.js
@@ -305,7 +305,6 @@
 		if ( self.isDialog ) {
 			$(self.dialogPage).dialog('close');
 			self.sdIntContent.addClass('ui-simpledialog-hidden');
-			console.log(self.displayAnchor.parent());
 			self.sdIntContent.appendTo(self.displayAnchor.parent());
 			if ( $.mobile.activePage.jqmData("page").options.domCache != true && $.mobile.activePage.is(":jqmData(external-page='true')") ) {
 				$.mobile.activePage.bind("pagehide.remove", function () {

--- a/js/jquery.mobile.simpledialog2.js
+++ b/js/jquery.mobile.simpledialog2.js
@@ -351,7 +351,7 @@
 		}
 		else {
 		  $(self.sdIntContent).hide();
-    	}
+    }
 		
 		$(self.dialogPage).remove();
 		$(self.screen).remove();


### PR DESCRIPTION
I found that in some use cases removing the dialog content from the DOM after close displayed some funkiness in re-opening the dialog. In my specific case, I dynamically added hidden content into the DOM and only displayed it when a dialog was opened. Then when the dialog is closed and the content was removed from the DOM, it did not show up again within the dialog. To fix this I simply added an option to the simpledailog2 method called 'removeOnClose' that allows people to keep their dialog content in the DOM after the close button is clicked. The default value is true, which will keep the default behavior of removing the content. This option has to be set to false in order to just hide the content.
